### PR TITLE
Update the link to the doc for Executor

### DIFF
--- a/Image_Search_via_Text.ipynb
+++ b/Image_Search_via_Text.ipynb
@@ -215,7 +215,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to add to our Flow (our pipeline) an encoder for the image, so we are going to create an `Executor`. (see details documentation [here](https://docs.jina.ai/fundamentals/executor/https://docs.jina.ai/fundamentals/executor/))\n",
+    "We need to add to our Flow (our pipeline) an encoder for the image, so we are going to create an `Executor`. (see details documentation [here](https://docs.jina.ai/concepts/executor/))\n",
     "\n",
     "This encoder encodes an image into embeddings using the CLIP model. \n",
     "We want an executor that loads the CLIP model and encodes it during the index flow. \n",


### PR DESCRIPTION
The previous link was erroneous and broken. This update adds the correct link to the documentation for